### PR TITLE
Fixed error when building for the first time

### DIFF
--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -86,6 +86,15 @@ namespace InventoryKamera
 
 
             LocalVersion = new Version(File.ReadAllText(ListsDir + NewVersion));
+
+
+            if (!(File.Exists(ListsDir + WeaponsJson) &&
+                File.Exists(ListsDir + ArtifactsJson) &&
+                File.Exists(ListsDir + CharactersJson) &&
+                File.Exists(ListsDir + MaterialsJson)))
+            {
+                UpdateGameData(force: true);
+            }
         }
 
         public bool UpdateAvailable()


### PR DESCRIPTION
Fixed an error where building for the first time doesn't create the JSON files required by the DatabaseManager. Not particularly significant, but beneficial for anyone else wanting to fork the repository.