### PR TITLE
Added mapping for TextMap_MediumEN.json to match database split

### DIFF
--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -40,6 +40,7 @@ namespace InventoryKamera
         private const string commitsAPIURL = "https://gitlab.com/api/v4/projects/53216109/repository/commits";
         private const string repoBaseURL = "https://gitlab.com/Dimbreath/AnimeGameData/-/raw/master/";
         private const string TextMapEnURL = repoBaseURL + "TextMap/TextMapEN.json";
+        private const string TextMapMediumEnURL = repoBaseURL + "TextMap/TextMap_MediumEN.json";
         private const string CharactersURL = repoBaseURL + "ExcelBinOutput/AvatarExcelConfigData.json";
         private const string ConstellationsURL = repoBaseURL + "ExcelBinOutput/FetterInfoExcelConfigData.json";
         private const string TalentsURL = repoBaseURL + "ExcelBinOutput/AvatarTalentExcelConfigData.json";
@@ -260,10 +261,22 @@ namespace InventoryKamera
             {
                 if (!Mappings.Any())
                 {
-                    Mappings = new ConcurrentDictionary<string, string>(JObject.Parse(LoadJsonFromURLAsync(TextMapEnURL))
+                    var mapping = JObject.Parse(LoadJsonFromURLAsync(TextMapEnURL))
                         .ToObject<Dictionary<string, string>>()
                         .Where(e => !string.IsNullOrWhiteSpace(e.Value)) // Remove any mapping with empty
-                        .ToDictionary(i => i.Key, i => i.Value));
+                        .ToDictionary(i => i.Key, i => i.Value);
+
+                    var mediumMapping = JObject.Parse(LoadJsonFromURLAsync(TextMapMediumEnURL))
+                        .ToObject<Dictionary<string, string>>()
+                        .Where(e => !string.IsNullOrWhiteSpace(e.Value)) // Remove any mapping with empty
+                        .ToDictionary(i => i.Key, i => i.Value);
+
+                    foreach (var entry in mediumMapping)
+                    {
+                        mapping[entry.Key] = entry.Value; // Should be no overlap
+                    }
+
+                    Mappings = new ConcurrentDictionary<string, string>(mapping);
                 }
             }
         }

--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -380,6 +380,8 @@ namespace InventoryKamera
                         string nameKey = nameGOOD.ToLower();
                         int characterID = (int)character["id"];
 
+                        if (characterID > 10000900) return; // Not playable characters
+
                         string const3Description = "";
                         string const5Description = "";
                         string skill = "";


### PR DESCRIPTION
Fixes #19 after the database from which text mappings are retrieved split the single TextMapEN.json into both that and TextMap_MediumEN.json.