### PR TITLE
Fix database update data loss from optimistic delete anti-pattern

### DIFF
--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -350,11 +350,14 @@ namespace InventoryKamera
 
         private UpdateStatus UpdateCharacters(bool force)
         {
-            if (force) File.Delete(ListsDir + CharactersJson);
-
             var status = UpdateStatus.Skipped;
 
-            var data = JToken.Parse(LoadJsonFromFile(CharactersJson)).ToObject<ConcurrentDictionary<string, JObject>>();
+            // Load existing data (or empty dict if file doesn't exist or force mode)
+            var data = force
+                ? new ConcurrentDictionary<string, JObject>()
+                : JToken.Parse(LoadJsonFromFile(CharactersJson)).ToObject<ConcurrentDictionary<string, JObject>>();
+
+            var newData = new ConcurrentDictionary<string, JObject>(data);
 
             try
             {
@@ -389,7 +392,7 @@ namespace InventoryKamera
 
                         var value = new JObject();
 
-                        if (!data.ContainsKey(nameKey))
+                        if (!newData.ContainsKey(nameKey))
                         {
                             value.Add("GOOD", nameGOOD);
 
@@ -498,7 +501,7 @@ namespace InventoryKamera
 
                             value.Add("WeaponType", (int)weaponType);
 
-                            if (data.TryAdd(nameKey, value)) status = UpdateStatus.Success;
+                            if (newData.TryAdd(nameKey, value)) status = UpdateStatus.Success;
                         }
                     }
                     catch (Exception ex)
@@ -535,21 +538,87 @@ namespace InventoryKamera
             {
                 Logger.Warn(ex);
                 status = UpdateStatus.Fail;
-            }            
+            }
 
+            // Validate the new data before saving
             if (status == UpdateStatus.Success)
-                SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, JObject>(data)), CharactersJson);
+            {
+                if (ValidateCharacterData(newData))
+                {
+                    Logger.Info("Character data validation passed. Saving {0} characters.", newData.Count);
+                    SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, JObject>(newData)), CharactersJson);
+                }
+                else
+                {
+                    Logger.Error("Character data validation failed. Keeping existing data.");
+                    status = UpdateStatus.Fail;
+                }
+            }
 
             return status;
         }
 
+        private bool ValidateCharacterData(ConcurrentDictionary<string, JObject> data)
+        {
+            // Sanity checks to prevent saving corrupt/empty data
+            if (data == null || data.Count == 0)
+            {
+                Logger.Error("Validation failed: Character data is null or empty");
+                return false;
+            }
+
+            // Expect at least 50 characters (as of 6.5.0 there are 90+)
+            if (data.Count < 50)
+            {
+                Logger.Error("Validation failed: Only {0} characters found (expected at least 50)", data.Count);
+                return false;
+            }
+
+            // Check that critical characters exist (sanity check for complete data)
+            string[] criticalCharacters = { "traveler", "amber", "kaeya", "lisa" };
+            foreach (var charKey in criticalCharacters)
+            {
+                if (!data.ContainsKey(charKey))
+                {
+                    Logger.Error("Validation failed: Missing critical character '{0}'", charKey);
+                    return false;
+                }
+            }
+
+            // Validate structure of a sample character
+            foreach (var kvp in data.Take(5))
+            {
+                var charData = kvp.Value;
+                if (!charData.ContainsKey("GOOD") ||
+                    !charData.ContainsKey("Element") ||
+                    !charData.ContainsKey("WeaponType"))
+                {
+                    Logger.Error("Validation failed: Character '{0}' missing required fields", kvp.Key);
+                    return false;
+                }
+
+                // Check ConstellationOrder exists (except for traveler which has element-specific)
+                if (kvp.Key != "traveler" && !charData.ContainsKey("ConstellationOrder"))
+                {
+                    Logger.Error("Validation failed: Character '{0}' missing ConstellationOrder", kvp.Key);
+                    return false;
+                }
+            }
+
+            Logger.Debug("Character data validation passed: {0} characters, all checks OK", data.Count);
+            return true;
+        }
+
         private UpdateStatus UpdateArtifacts(bool force)
         {
-            if (force) File.Delete(ListsDir + ArtifactsJson);
-
             var status = UpdateStatus.Skipped;
 
-            var data = JToken.Parse(LoadJsonFromFile(ArtifactsJson)).ToObject<ConcurrentDictionary<string, JObject>>();
+            // Load existing data (or empty dict if file doesn't exist or force mode)
+            var data = force
+                ? new ConcurrentDictionary<string, JObject>()
+                : JToken.Parse(LoadJsonFromFile(ArtifactsJson)).ToObject<ConcurrentDictionary<string, JObject>>();
+
+            var newData = new ConcurrentDictionary<string, JObject>(data);
 
             var artifactDisplays = JArray.Parse(LoadJsonFromURLAsync(ArtifactsDisplayItemURL)).ToObject<List<JObject>>();
             artifactDisplays.RemoveAll(a => a.TryGetValue("icon", out var icon) && !icon.ToString().Contains("RelicIcon"));
@@ -570,7 +639,7 @@ namespace InventoryKamera
                         var setNameNormalized = setName;
                         var setID = (int)artifactDisplay["param"];
 
-                        if (!data.ContainsKey(setNameKey))
+                        if (!newData.ContainsKey(setNameKey))
                         {
                             foreach (var set in codex)
                             {
@@ -612,7 +681,7 @@ namespace InventoryKamera
                                     { "normalizedName", setNameGOOD.ToLower() },
                                     { "artifacts", artifacts }
                                 };
-                                if (data.TryAdd(setNameKey, value) && status != UpdateStatus.Fail) status = UpdateStatus.Success;
+                                if (newData.TryAdd(setNameKey, value) && status != UpdateStatus.Fail) status = UpdateStatus.Success;
                             }
                         }
                     }
@@ -625,19 +694,76 @@ namespace InventoryKamera
                 }
             });
 
+            // Validate the new data before saving
             if (status == UpdateStatus.Success)
-                SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, JObject>(data)), ArtifactsJson);
+            {
+                if (ValidateArtifactData(newData))
+                {
+                    Logger.Info("Artifact data validation passed. Saving {0} artifact sets.", newData.Count);
+                    SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, JObject>(newData)), ArtifactsJson);
+                }
+                else
+                {
+                    Logger.Error("Artifact data validation failed. Keeping existing data.");
+                    status = UpdateStatus.Fail;
+                }
+            }
 
             return status;
         }
 
+        private bool ValidateArtifactData(ConcurrentDictionary<string, JObject> data)
+        {
+            if (data == null || data.Count == 0)
+            {
+                Logger.Error("Validation failed: Artifact data is null or empty");
+                return false;
+            }
+
+            // Expect at least 30 artifact sets (as of 6.5.0 there are 40+)
+            if (data.Count < 30)
+            {
+                Logger.Error("Validation failed: Only {0} artifact sets found (expected at least 30)", data.Count);
+                return false;
+            }
+
+            // Check that critical artifact sets exist
+            string[] criticalSets = { "gladiatorsfinale", "wandererstroupe", "noblesseoblige" };
+            foreach (var setKey in criticalSets)
+            {
+                if (!data.ContainsKey(setKey))
+                {
+                    Logger.Error("Validation failed: Missing critical artifact set '{0}'", setKey);
+                    return false;
+                }
+            }
+
+            // Validate structure of a sample set
+            foreach (var kvp in data.Take(3))
+            {
+                var setData = kvp.Value;
+                if (!setData.ContainsKey("GOOD") ||
+                    !setData.ContainsKey("artifacts"))
+                {
+                    Logger.Error("Validation failed: Artifact set '{0}' missing required fields", kvp.Key);
+                    return false;
+                }
+            }
+
+            Logger.Debug("Artifact data validation passed: {0} sets, all checks OK", data.Count);
+            return true;
+        }
+
         private UpdateStatus UpdateWeapons(bool force)
         {
-            if (force) File.Delete(ListsDir + WeaponsJson);
-
             var status = UpdateStatus.Skipped;
 
-            var data = JToken.Parse(LoadJsonFromFile(WeaponsJson)).ToObject<ConcurrentDictionary<string, string>>();
+            // Load existing data (or empty dict if file doesn't exist or force mode)
+            var data = force
+                ? new ConcurrentDictionary<string, string>()
+                : JToken.Parse(LoadJsonFromFile(WeaponsJson)).ToObject<ConcurrentDictionary<string, string>>();
+
+            var newData = new ConcurrentDictionary<string, string>(data);
 
             try
             {
@@ -654,7 +780,7 @@ namespace InventoryKamera
                             string nameGOOD = Regex.Replace(PascalCase, @"[\W]", string.Empty);              // DullBlade
                             string nameKey = nameGOOD.ToLower();                                             // dullblade
 
-                            if (!data.TryAdd(nameKey, nameGOOD)) status = UpdateStatus.Success;
+                            if (newData.TryAdd(nameKey, nameGOOD)) status = UpdateStatus.Success;
                         }
                         else Logger.Warn("Weapon hash {0} not found in Mappings. It's likely unreleased.", weapon["nameTextMapHash"].ToString());
                     }
@@ -667,16 +793,56 @@ namespace InventoryKamera
                 status = UpdateStatus.Fail;
             }
 
+            // Validate the new data before saving
             if (status == UpdateStatus.Success)
-                SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, string>(data)), WeaponsJson);
+            {
+                if (ValidateWeaponData(newData))
+                {
+                    Logger.Info("Weapon data validation passed. Saving {0} weapons.", newData.Count);
+                    SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, string>(newData)), WeaponsJson);
+                }
+                else
+                {
+                    Logger.Error("Weapon data validation failed. Keeping existing data.");
+                    status = UpdateStatus.Fail;
+                }
+            }
 
             return status;
         }
 
+        private bool ValidateWeaponData(ConcurrentDictionary<string, string> data)
+        {
+            if (data == null || data.Count == 0)
+            {
+                Logger.Error("Validation failed: Weapon data is null or empty");
+                return false;
+            }
+
+            // Expect at least 100 weapons (as of 6.5.0 there are 150+)
+            if (data.Count < 100)
+            {
+                Logger.Error("Validation failed: Only {0} weapons found (expected at least 100)", data.Count);
+                return false;
+            }
+
+            // Check that critical weapons exist
+            string[] criticalWeapons = { "dullblade", "silvansword", "beginnerprotector" };
+            foreach (var weaponKey in criticalWeapons)
+            {
+                if (!data.ContainsKey(weaponKey))
+                {
+                    Logger.Error("Validation failed: Missing critical weapon '{0}'", weaponKey);
+                    return false;
+                }
+            }
+
+            Logger.Debug("Weapon data validation passed: {0} weapons, all checks OK", data.Count);
+            return true;
+        }
+
         private UpdateStatus UpdateMaterials(bool force)
         {
-            if (force) File.Delete(ListsDir + MaterialsJson);
-
             var status = UpdateStatus.Skipped;
 
             var materialCategories = new List<string>
@@ -689,7 +855,12 @@ namespace InventoryKamera
                 "MATERIAL_WEAPON_EXP_STONE",
             };
 
-            var data = JToken.Parse(LoadJsonFromFile(MaterialsJson)).ToObject<ConcurrentDictionary<string, string>>();
+            // Load existing data (or empty dict if file doesn't exist or force mode)
+            var data = force
+                ? new ConcurrentDictionary<string, string>()
+                : JToken.Parse(LoadJsonFromFile(MaterialsJson)).ToObject<ConcurrentDictionary<string, string>>();
+
+            var newData = new ConcurrentDictionary<string, string>(data);
 
             var materials = JArray.Parse(LoadJsonFromURLAsync(MaterialsURL)).ToObject<List<JObject>>();
             materials.RemoveAll(material => !(material.TryGetValue("materialType", out var materialType) && materialCategories.Contains(materialType.ToString())));
@@ -705,7 +876,7 @@ namespace InventoryKamera
                         var nameGood = Regex.Replace(PascalCase, @"[\W]", string.Empty);
                         var nameKey = nameGood.ToLower();
 
-                        if (data.TryAdd(nameKey, nameGood) && status != UpdateStatus.Fail) status = UpdateStatus.Success;
+                        if (newData.TryAdd(nameKey, nameGood) && status != UpdateStatus.Fail) status = UpdateStatus.Success;
                     }
                     else
                     {
@@ -715,10 +886,41 @@ namespace InventoryKamera
                 catch (Exception ex) { Logger.Warn(ex); }
             });
 
+            // Validate the new data before saving
             if (status == UpdateStatus.Success)
-                SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, string>(data)), MaterialsJson);
+            {
+                if (ValidateMaterialData(newData))
+                {
+                    Logger.Info("Material data validation passed. Saving {0} materials.", newData.Count);
+                    SaveJsonToFile(JsonConvert.SerializeObject(new SortedDictionary<string, string>(newData)), MaterialsJson);
+                }
+                else
+                {
+                    Logger.Error("Material data validation failed. Keeping existing data.");
+                    status = UpdateStatus.Fail;
+                }
+            }
 
             return status;
+        }
+
+        private bool ValidateMaterialData(ConcurrentDictionary<string, string> data)
+        {
+            if (data == null || data.Count == 0)
+            {
+                Logger.Error("Validation failed: Material data is null or empty");
+                return false;
+            }
+
+            // Expect at least 50 materials (as of 6.5.0 there are 100+)
+            if (data.Count < 50)
+            {
+                Logger.Error("Validation failed: Only {0} materials found (expected at least 50)", data.Count);
+                return false;
+            }
+
+            Logger.Debug("Material data validation passed: {0} materials, all checks OK", data.Count);
+            return true;
         }
 
         private string FetchHTML(string url)


### PR DESCRIPTION
## Critical Bug Fix: Prevents Complete Data Loss During Forced Database Updates

### Problem
The current database update implementation has a critical "optimistic delete" anti-pattern that causes **complete data loss** (0-byte files) when forced updates fail:

1. `if (force) File.Delete(file)` - **deletes existing data FIRST**
2. `LoadJsonFromFile()` creates empty 0-byte file
3. If processing fails → `status` stays `Skipped`
4. File never saved → **0-byte file remains = DATA LOSS**

This affects all 4 data types: characters, weapons, artifacts, and materials.

### Solution
Implemented proper **download-validate-replace pattern**:

1. Load existing data (or empty dict if force mode)
2. Work on copy (`newData`), keeping original as fallback
3. Process updates into `newData`
4. **Validate `newData` before saving** (new validation methods)
5. Only replace file if validation passes
6. If validation fails → keep existing data, log error

### Changes

**Database Update Methods** (UpdateCharacters, UpdateWeapons, UpdateArtifacts, UpdateMaterials):
- ❌ Removed all `File.Delete()` calls before download
- ✅ Work on `newData` copy, preserve original as fallback
- ✅ Only save if validation passes

**New Validation Methods**:
- `ValidateCharacterData()`: ≥50 chars, critical chars exist (amber, kaeya, lisa, traveler)
- `ValidateWeaponData()`: ≥100 weapons
- `ValidateArtifactData()`: ≥30 sets, critical sets exist (gladiators, wanderers, noblesse)
- `ValidateMaterialData()`: ≥50 materials

### Impact
- ✅ **No more 0-byte data loss** on failed forced updates
- ✅ **Atomic updates**: either fully succeed or keep existing data intact
- ✅ **Validation prevents corrupt data** from being saved
- ✅ **Graceful degradation**: unreleased content skipped with warnings, released content saved

### Testing
Tested with forced database update containing unreleased 6.5.0 content:
- ✅ Validation passed for all data types
- ✅ No 0-byte files
- ✅ Unreleased content gracefully skipped
- ✅ All released content successfully saved

### Files Changed
- `InventoryKamera/data/DatabaseManager.cs` (+225 lines, -23 lines)

---

This fix prevents a production-breaking bug that could leave users with completely empty database files. We discovered this when testing forced updates and encountered the exact scenario that causes data loss.